### PR TITLE
Fix houndci rubocop config

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,13 @@
+{
+  "parserOptions": {
+    "ecmaVersion": 7,
+    "ecmaFeatures": {
+      "jsx": true
+    },
+    "sourceType": "module"
+  },
+
+  "env": {
+    "es6": true
+  }
+}

--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,12 @@
+rubocop:
+  config_file: .rubocop.yml
+  version: 1.5.2
+
+reek:
+  enable: true
+  config_file: .reek.yml
+
+eslint:
+  enabled: true
+  config_file: .eslintrc
+  version: 7.7.0

--- a/.hound.yml
+++ b/.hound.yml
@@ -3,7 +3,7 @@ rubocop:
   version: 1.5.2
 
 reek:
-  enable: true
+  enabled: true
   config_file: .reek.yml
 
 eslint:

--- a/.reek.yml
+++ b/.reek.yml
@@ -1,0 +1,38 @@
+Attribute:
+  enabled: false
+
+DuplicateMethodCall:
+  max_calls: 3
+
+FeatureEnvy:
+  enabled: false
+
+IrresponsibleModule:
+  enabled: false
+
+PrimaDonnaMethod:
+  enabled: false
+
+TooManyStatements:
+  enabled: true
+  exclude:
+  - initialize
+  - perform
+  - change
+  - up
+  - down
+  max_statements: 5
+
+"app/workers":
+  UtilityFunction:
+    enabled: false
+
+"db/migrate":
+  DuplicateMethodCall:
+    enabled: false
+  NestedIterators:
+    enabled: false
+  UncommunicativeVariableName:
+    enabled: false
+  UtilityFunction:
+    enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 AllCops:
   Exclude:
-    - 'db/schema.rb'
-    - 'vendor/bundle/**/*'
+    - '**/db/schema.rb'
+    - '**/vendor/bundle/**/*'
 
 require:
   - rubocop-rails
@@ -21,8 +21,8 @@ Metrics/BlockLength:
   Max: 25
   ExcludedMethods: []
   Exclude:
-    - 'config/routes.rb'
-    - 'spec/**/*'
+    - '**/config/routes.rb'
+    - '**/spec/**/*'
 
 Style/Documentation:
   Enabled: false
@@ -32,8 +32,9 @@ Style/DoubleNegation:
 
 Style/FrozenStringLiteralComment:
   Exclude:
-    - 'db/migrate/*.rb'
+    - '**/db/migrate/*.rb'
     - Gemfile
+    - '**/Gemfile'
 
 Metrics/MethodLength:
   Max: 15

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,45 @@
+AllCops:
+  Exclude:
+    - 'db/schema.rb'
+    - 'vendor/bundle/**/*'
+
+require:
+  - rubocop-rails
+  - rubocop-performance
+
+Metrics/ClassLength:
+  Enabled: false
+
+Metrics/ModuleLength:
+  Enabled: false
+
+Metrics/AbcSize:
+  Enabled: false
+
+Metrics/BlockLength:
+  CountComments: true  # count full line comments?
+  Max: 25
+  ExcludedMethods: []
+  Exclude:
+    - 'config/routes.rb'
+    - 'spec/**/*'
+
+Style/Documentation:
+  Enabled: false
+
+Style/DoubleNegation:
+  Enabled: false
+
+Style/FrozenStringLiteralComment:
+  Exclude:
+    - 'db/migrate/*.rb'
+
+Metrics/MethodLength:
+  Max: 15
+
+Layout/LineLength:
+  Description: 'Limit lines to 120 characters.'
+  Max: 120
+
+Lint/Loop:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -33,6 +33,7 @@ Style/DoubleNegation:
 Style/FrozenStringLiteralComment:
   Exclude:
     - 'db/migrate/*.rb'
+    - Gemfile
 
 Metrics/MethodLength:
   Max: 15

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+gem 'rubocop-performance'
+gem 'rubocop-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,54 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (6.1.3.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+      zeitwerk (~> 2.3)
+    ast (2.4.2)
+    concurrent-ruby (1.1.8)
+    i18n (1.8.10)
+      concurrent-ruby (~> 1.0)
+    minitest (5.14.4)
+    parallel (1.20.1)
+    parser (3.0.1.0)
+      ast (~> 2.4.1)
+    rack (2.2.3)
+    rainbow (3.0.0)
+    regexp_parser (2.1.1)
+    rexml (3.2.5)
+    rubocop (1.12.1)
+      parallel (~> 1.10)
+      parser (>= 3.0.0.0)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml
+      rubocop-ast (>= 1.2.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.4.1)
+      parser (>= 2.7.1.5)
+    rubocop-performance (1.10.2)
+      rubocop (>= 0.90.0, < 2.0)
+      rubocop-ast (>= 0.4.0)
+    rubocop-rails (2.9.1)
+      activesupport (>= 4.2.0)
+      rack (>= 1.1)
+      rubocop (>= 0.90.0, < 2.0)
+    ruby-progressbar (1.11.0)
+    tzinfo (2.0.4)
+      concurrent-ruby (~> 1.0)
+    unicode-display_width (2.0.0)
+    zeitwerk (2.4.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  rubocop-performance
+  rubocop-rails
+
+BUNDLED WITH
+   2.0.2


### PR DESCRIPTION
### HoundCi config
- Added `hound.yml`, `.rubocop.yml`, `.reek.yml`, `.eslintrc.json` configuration files
- Gemfile includes `rubocop-rails` and `rubocop-performance` because `rubocop.yml` using those extensions

